### PR TITLE
Clarify proxy settings if no proxy needed/unsure

### DIFF
--- a/cpt-quickstart.rst
+++ b/cpt-quickstart.rst
@@ -87,6 +87,9 @@ To install, proceed according to the following steps:
     the Stratum 1 web servers (more on :ref:`proxy configuration here <cpt_squid>`). For Cern
     repositories, the Stratum 1 web servers are listed in
     /etc/cvmfs/domain.d/cern.ch.conf.
+    
+    If you're unsure about the proxy names, set
+    ``CVMFS_HTTP_PROXY=DIRECT``.
 
 **Step 5**
     Check if CernVM-FS mounts the specified repositories by


### PR DESCRIPTION
Previously unclear what to include in the config file if no proxies were required. Information was there for Mac OSX instructions but not Linux